### PR TITLE
Ignored generated file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 # Composer
 vendor/
 composer.phar
+composer.lock


### PR DESCRIPTION
`composer.lock` is a Composer generated file and should be ignored.