### PR TITLE
Enhance Administration class to set password for user

### DIFF
--- a/src/Administration.php
+++ b/src/Administration.php
@@ -19,10 +19,10 @@ final class Administration extends UserManager {
 	/**
 	 * @internal
 	 *
-	 * @param PdoDatabase $databaseConnection the database connection to operate on
+	 * @param PdoDatabase|PdoDsn|\PDO $databaseConnection the database connection to operate on
 	 * @param string|null $dbTablePrefix (optional) the prefix for the names of all database tables used by this component
 	 */
-	public function __construct(PdoDatabase $databaseConnection, $dbTablePrefix = null) {
+	public function __construct($databaseConnection, $dbTablePrefix = null) {
 		parent::__construct($databaseConnection, $dbTablePrefix);
 	}
 
@@ -368,6 +368,24 @@ final class Administration extends UserManager {
 		elseif ($numberOfMatchedUsers > 1) {
 			throw new AmbiguousUsernameException();
 		}
+	}
+
+	/**
+	 * Sets the given user's password by setting it to the new specified password
+	 * 
+	 * @param string $username the username of the user whose password should be set
+	 * @param string $newPassword the new password
+	 */
+	public function changePasswordByUsername($username, $newPassword) {
+		$userData = $this->getUserDataByUsername(
+			\trim($username),
+			[ 'id' ]
+		);
+
+		$this->updatePasswordInternal(
+			(int) $userData['id'],
+			$newPassword
+		);
 	}
 
 	/**

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -717,33 +717,11 @@ final class Auth extends UserManager {
 		if ($this->isLoggedIn()) {
 			$newPassword = self::validatePassword($newPassword);
 			$userId = $this->getUserId();
-			$this->updatePassword($userId, $newPassword);
+			$this->updatePasswordInternal($userId, $newPassword);
 			$this->deleteRememberDirective($userId);
 		}
 		else {
 			throw new NotLoggedInException();
-		}
-	}
-
-	/**
-	 * Updates the given user's password by setting it to the new specified password
-	 *
-	 * @param int $userId the ID of the user whose password should be updated
-	 * @param string $newPassword the new password
-	 * @throws AuthError if an internal problem occurred (do *not* catch)
-	 */
-	private function updatePassword($userId, $newPassword) {
-		$newPassword = \password_hash($newPassword, \PASSWORD_DEFAULT);
-
-		try {
-			$this->db->update(
-				$this->dbTablePrefix . 'users',
-				[ 'password' => $newPassword ],
-				[ 'id' => $userId ]
-			);
-		}
-		catch (Error $e) {
-			throw new DatabaseError();
 		}
 	}
 
@@ -1025,7 +1003,7 @@ final class Auth extends UserManager {
 			// if the password needs to be re-hashed to keep up with improving password cracking techniques
 			if (\password_needs_rehash($userData['password'], \PASSWORD_DEFAULT)) {
 				// create a new hash from the password and update it in the database
-				$this->updatePassword($userData['id'], $password);
+				$this->updatePasswordInternal($userData['id'], $password);
 			}
 
 			if ((int) $userData['verified'] === 1) {
@@ -1220,7 +1198,7 @@ final class Auth extends UserManager {
 						$newPassword = self::validatePassword($newPassword);
 
 						// update the password in the database
-						$this->updatePassword($resetData['user'], $newPassword);
+						$this->updatePasswordInternal($resetData['user'], $newPassword);
 
 						// delete any remaining remember directives
 						$this->deleteRememberDirective($resetData['user']);

--- a/src/UserManager.php
+++ b/src/UserManager.php
@@ -183,6 +183,28 @@ abstract class UserManager {
 	}
 
 	/**
+	 * Updates the given user's password by setting it to the new specified password
+	 *
+	 * @param int $userId the ID of the user whose password should be updated
+	 * @param string $newPassword the new password
+	 * @throws AuthError if an internal problem occurred (do *not* catch)
+	 */
+	protected function updatePasswordInternal($userId, $newPassword) {
+		$newPassword = \password_hash($newPassword, \PASSWORD_DEFAULT);
+
+		try {
+			$this->db->update(
+				$this->dbTablePrefix . 'users',
+				[ 'password' => $newPassword ],
+				[ 'id' => $userId ]
+			);
+		}
+		catch (Error $e) {
+			throw new DatabaseError();
+		}
+	}
+
+	/**
 	 * Called when a user has successfully logged in
 	 *
 	 * This may happen via the standard login, via the "remember me" feature, or due to impersonation by administrators


### PR DESCRIPTION
- Administration constructor now also allows PdoDsn and \PDO instances for the $databaseConnection parameter
- Moved updatePassword from Auth to UserManager
- Renamed updatePassword to updatePasswordInternal
- Added changePasswordByUsername to Administration class