### PR TITLE
Ability to retrieve a list with all usernames

### DIFF
--- a/src/Administration.php
+++ b/src/Administration.php
@@ -413,6 +413,24 @@ final class Administration extends UserManager {
 	}
 
 	/**
+	 * Gets a list of all usernames. The list will be in ascending order.
+	 * 
+	 * @throws AuthError if an internal problem occurred (do *not* catch)
+	 */
+	public function getUsernames() {
+		try {
+			$usernames = $this->db->selectColumn(
+				'SELECT username FROM users ORDER BY username ASC'
+			);
+
+			return $usernames;
+		}
+		catch (Error $e) {
+			throw new DatabaseError();
+		}
+	}
+
+	/**
 	 * Deletes all existing users where the column with the specified name has the given value
 	 *
 	 * You must never pass untrusted input to the parameter that takes the column name


### PR DESCRIPTION
Added a function called `getUsernames()` to the `Administration` class which returns a list (in ascending order) with all usernames existing in the database.